### PR TITLE
feat(favorite): implement favorite artice function

### DIFF
--- a/prisma/migrations/20250729031852_add_favorites_table/migration.sql
+++ b/prisma/migrations/20250729031852_add_favorites_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE `Favorite` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NOT NULL,
+    `articleId` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `Favorite_userId_idx`(`userId`),
+    INDEX `Favorite_articleId_idx`(`articleId`),
+    UNIQUE INDEX `Favorite_userId_articleId_key`(`userId`, `articleId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Favorite` ADD CONSTRAINT `Favorite_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Favorite` ADD CONSTRAINT `Favorite_articleId_fkey` FOREIGN KEY (`articleId`) REFERENCES `Article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,9 +26,10 @@ model User {
   articles Article[]
   comments Comment[]
 
-  // Follow relationships
   followers Follow[] @relation("UserFollowers")
   following Follow[] @relation("UserFollowing")
+
+  favoriteArticles Favorite[]
 }
 
 //favourited & favoritedCount will be added later
@@ -45,9 +46,24 @@ model Article {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  comments Comment[]
+  comments  Comment[]
+  favorites Favorite[]
 
   @@index([authorId])
+}
+
+model Favorite {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  articleId Int
+  createdAt DateTime @default(now())
+
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  article Article @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, articleId])
+  @@index([userId])
+  @@index([articleId])
 }
 
 model Comment {

--- a/src/article/article.controller.ts
+++ b/src/article/article.controller.ts
@@ -81,4 +81,22 @@ export class ArticleController {
   ): Promise<DeleteArticleResponseDto> {
     return this.articleService.deleteArticle(slug, user.id);
   }
+
+  @Post(':slug/favorite')
+  @UseGuards(JwtAuthGuard)
+  async favoriteArticle(
+    @Param('slug') slug: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ArticleResponseDto> {
+    return this.articleService.favoriteArticle(slug, user.id);
+  }
+
+  @Delete(':slug/favorite')
+  @UseGuards(JwtAuthGuard)
+  async unfavoriteArticle(
+    @Param('slug') slug: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ArticleResponseDto> {
+    return this.articleService.unfavoriteArticle(slug, user.id);
+  }
 }


### PR DESCRIPTION
This pull request introduces a new "favorites" feature, allowing users to favorite and unfavorite articles. The changes span database schema updates, Prisma model adjustments, and backend service/controller implementations to support this functionality.

### Database and Schema Updates:
* Added a new `Favorite` table in the database to store user-article favorite relationships, including foreign keys to `User` and `Article` tables with cascade delete behavior. (`prisma/migrations/20250729031852_add_favorites_table/migration.sql`)
* Updated the Prisma schema to include a `Favorite` model and added relations in the `User` and `Article` models to link with the `Favorite` table. (`prisma/schema.prisma`) [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL29-R32) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR50-R68)

### Backend API Enhancements:
* Added `POST /articles/:slug/favorite` and `DELETE /articles/:slug/favorite` endpoints in the `ArticleController` for favoriting and unfavoriting articles. (`src/article/article.controller.ts`)
* Implemented `favoriteArticle` and `unfavoriteArticle` methods in the `ArticleService` to handle the business logic for the new endpoints, including validation and interaction with the `Favorite` table. (`src/article/article.service.ts`)

### Article Metadata Enhancements:
* Updated article responses to include `favorited` and `favoritesCount` fields, reflecting whether the current user has favorited the article and the total number of favorites. (`src/article/article.service.ts`) [[1]](diffhunk://#diff-78fd0c2eaa6298803f14e693c5dbbc4d22f3a3c13f2df7f75620a7c0fd1d2f18R493) [[2]](diffhunk://#diff-78fd0c2eaa6298803f14e693c5dbbc4d22f3a3c13f2df7f75620a7c0fd1d2f18R511-R529) [[3]](diffhunk://#diff-78fd0c2eaa6298803f14e693c5dbbc4d22f3a3c13f2df7f75620a7c0fd1d2f18L370-R541)
* Optimized metadata computation by preloading favorite data into `favoriteMap` and `favoritesCountMap` for batch processing in list and feed queries. (`src/article/article.service.ts`) [[1]](diffhunk://#diff-78fd0c2eaa6298803f14e693c5dbbc4d22f3a3c13f2df7f75620a7c0fd1d2f18R330-R332) [[2]](diffhunk://#diff-78fd0c2eaa6298803f14e693c5dbbc4d22f3a3c13f2df7f75620a7c0fd1d2f18L320-R480)

These changes collectively enable the favorites feature, enhancing user engagement and providing more detailed article metadata.